### PR TITLE
Add italian translation

### DIFF
--- a/src/main/resources/eu/hansolo/fx/glucostatus/i18n/gsfx_it.properties
+++ b/src/main/resources/eu/hansolo/fx/glucostatus/i18n/gsfx_it.properties
@@ -1,0 +1,131 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2022 Gerrit Grunwald.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+app_name                                          = Gluco Status FX
+
+menu                                              = Menu
+about_menu_item                                   = Informazioni
+chart_menu_item                                   = Grafico
+preferences_menu_item                             = Preferenze
+quit_menu_item                                    = Esci
+
+about_alert_close_button                          = Chiudi
+
+back_button                                       = indietro
+settings_button                                   = Impostazioni
+
+date_time_format                                  = dd/MM/yy h\:mm a
+date_format                                       = yyyy-MM-dd'T'HH\:mm\:ssZ
+time_format                                       = h\:mm a
+
+time_name_720_hours                               = 30 g
+time_name_168_hours                               = 7 g
+time_name_72_hours                                = 72 h
+time_name_48_hours                                = 48 h
+time_name_24_hours                                = 24 h
+time_name_12_hours                                = 12 h
+time_name_6_hours                                 = 6 h
+time_name_3_hours                                 = 3 h
+
+time_range_720_hours                              = 30 Giorni
+time_range_168_hours                              = 7 Giorni
+time_range_72_hours                               = 72 Ore
+time_range_48_hours                               = 48 Ore
+time_range_24_hours                               = 24 Ore
+time_range_12_hours                               = 12 Ore
+time_range_6_hours                                = 6 Ore
+time_range_3_hours                                = 3 Ore
+
+status_name_none                                  = Nessuno
+status_name_too_low                               = Troppo basso
+status_name_low                                   = Basso
+status_name_acceptable_low                        = Basso Accettabile
+status_normal                                     = Normale
+status_acceptable_high                            = Alto Accettabile
+status_high                                       = Alto
+status_too_high                                   = Troppo Alto
+
+pattern_title                                     = Pattern 24h (ultima settimana)
+pattern_close_button                              = Close
+pattern_generally_too_high                        = Tipicamente troppo alto
+pattern_generally_too_low                         = Tipicamente troppo basso
+
+hbac1_range                                       = (ultimi 30 giorni)
+
+statistic_title                                   = Nell'intervallo di riferimento
+statistic_too_high                                = Molto alto
+statistic_high                                    = Alto
+statistic_normal                                  = Nell'intervallo di riferimento
+statistic_low                                     = Basso
+statistic_too_low                                 = Molto basso
+statistic_close_button                            = Chiudi
+statistic_low_zone                                = Valori bassi
+statistic_high_zone                               = Valori alti
+statistic_night                                   = notturno
+statistic_morning                                 = al mattino
+statistic_lunchtime                               = a pranzo
+statistic_afternoon                               = nel pomeriggio
+statistic_day                                     = durante il giorno
+statistic_evening                                 = alla sera
+
+notification_title                                = Attenzione
+notification_glucose_too_high                     = Glucosio troppo alto
+notification_glucose_soon_too_high                = Glucosio troppo alto tra poco
+notification_glucose_high                         = Glucosio alto
+notification_glucose_soon_high                    = Glucosio alto tra poco
+notification_glucose_a_bit_high                   = Glucosio leggermente alto
+notification_glucose_soon_low                     = Glucosio basso tra poco
+notification_glucose_a_bit_low                    = Glucosio leggermente basso
+notification_glucose_soon_too_low                 = Glucosio troppo basso tra poco
+notification_glucose_low                          = Glucosio basso
+notification_glucose_too_low                      = Glucosio troppo basso
+
+settings_title                                    = IMPOSTAZIONI
+settings_nightscouturl                            = Nightscout URL (https://NIGHTSCOUT_URL)
+settings_unitmg                                   = Unità mg/dl
+settings_unitmmol                                 = Unità mmol/l
+settings_show_deltachart                          = Mostra grafico degli ultimi 12 valori di delta
+settings_notifications_title                      = Notifiche
+settings_too_low_value_notification               = Troppo basso
+settings_too_low_value_notification_sound         = Suono
+settings_low_value_notification                   = Basso
+settings_low_value_notification_sound             = Suono
+settings_acceptable_low_value_notification        = Basso accettabile
+settings_acceptable_low_value_notification_sound  = Suono
+settings_acceptable_high_value_notification       = Alto accettabile
+settings_acceptable_high_value_notification_sound = Suono
+settings_high_value_notification                  = Alto
+settings_high_value_notification_sound            = Suono
+settings_too_high_value_notification              = Troppo alto
+settings_too_high_value_notification_sound        = Suono
+settings_too_low_notification_interval            = Intervallo troppo basso\: 
+settings_too_high_notification_interval           = Intervallo troppo alto\: 
+settings_ranges_title                             = Intervalli
+settings_min_acceptable                           = Min accettabile 
+settings_min_normal                               = Min normale 
+settings_max_normal                               = Max normale 
+settings_max_acceptable                           = Max accettabile 
+settings_smoothed_charts                          = Grafici smussati
+
+prediction_title_too_low                          = Attenzione
+prediction_too_low                                = Glucosio troppo basso tra poco !
+prediction_title_too_high                         = Attenzione
+prediction_too_high                               = Glucosio troppo alto tra poco !
+
+pattern_view_no_patterns                          = Nessun pattern trovato


### PR DESCRIPTION
I verified that starting the app with `-Duser.language=it` it loads up the correct labels, but I couldn't test all the labels since I don't have a valid Nightscout URL